### PR TITLE
Converted Module enum into a class, making assemble an instance method

### DIFF
--- a/AppModule.xctemplate/___VARIABLE_moduleName:identifier___Contract.swift
+++ b/AppModule.xctemplate/___VARIABLE_moduleName:identifier___Contract.swift
@@ -1,6 +1,12 @@
 import Foundation
 
-protocol ___VARIABLE_moduleName___Routing: AnyObject {}
+protocol ___VARIABLE_moduleName___ModuleType {
+    func assemble() -> UIViewController
+}
+
+protocol ___VARIABLE_moduleName___Routing: AnyObject {
+    var rootViewController: UIViewController? { get set }
+}
 
 protocol ___VARIABLE_moduleName___Presenting: AnyObject {
     var interactor: ___VARIABLE_moduleName___Interacting! { get set }

--- a/AppModule.xctemplate/___VARIABLE_moduleName:identifier___Module.swift
+++ b/AppModule.xctemplate/___VARIABLE_moduleName:identifier___Module.swift
@@ -1,7 +1,7 @@
-import Foundation
+import UIKit
 
-enum ___VARIABLE_moduleName___Module {
-    static func assemble() -> UIViewController {
+class ___VARIABLE_moduleName___Module: ___VARIABLE_moduleName___ModuleType {
+    func assemble() -> UIViewController {
         let router = ___VARIABLE_moduleName___Router()
         let view = ___VARIABLE_moduleName___ViewController()
         let presenter = ___VARIABLE_moduleName___Presenter()

--- a/AppModule.xctemplate/___VARIABLE_moduleName:identifier___ViewController.swift
+++ b/AppModule.xctemplate/___VARIABLE_moduleName:identifier___ViewController.swift
@@ -6,6 +6,6 @@ class ___VARIABLE_moduleName___ViewController: UIViewController, ___VARIABLE_mod
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        presenter.viewDidLoad()
     }
 }

--- a/Sample/BurritoContract.swift
+++ b/Sample/BurritoContract.swift
@@ -1,6 +1,12 @@
 import Foundation
 
-protocol BurritoRouting: AnyObject {}
+protocol BurritoModuleType {
+    func assemble() -> UIViewController
+}
+
+protocol BurritoRouting: AnyObject {
+    var rootViewController: UIViewController? { get set }
+}
 
 protocol BurritoPresenting: AnyObject {
     var interactor: BurritoInteracting! { get set }

--- a/Sample/BurritoModule.swift
+++ b/Sample/BurritoModule.swift
@@ -1,7 +1,7 @@
-import Foundation
+import UIKit
 
-enum BurritoModule {
-    static func assemble() -> UIViewController {
+class BurritoModule: BurritoModuleType {
+    func assemble() -> UIViewController {
         let router = BurritoRouter()
         let view = BurritoViewController()
         let presenter = BurritoPresenter()

--- a/Sample/BurritoViewController.swift
+++ b/Sample/BurritoViewController.swift
@@ -6,6 +6,6 @@ class BurritoViewController: UIViewController, BurritoViewable {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        presenter.viewDidLoad()
     }
 }


### PR DESCRIPTION
This allows for additional methods on the module from a parent module,
and it makes it easier to test routers (module class can be mocked).

As discussed in Platform Meeting, See also https://github.com/catawiki/iOS-Bidder-App/pull/2944