### PR TITLE
Added codeowners for code reviews

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in the repo
+* @catawiki/ios-team


### PR DESCRIPTION
With code-owners here, it should start working the same as https://github.com/catawiki/iOS-Bidder-App/pull/3949.