### PR TITLE
Silently delete the Old templates

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ mkdir -p "${TEMPLATE_PATH}"
 
 for TEMPLATE in *.xctemplate; do
     # Remove the old template
-    rm -r "${TEMPLATE_PATH}"/"${TEMPLATE}"
+    rm -f -r "${TEMPLATE_PATH}"/"${TEMPLATE}"
     # Copy the new template
     cp -r "${TEMPLATE}" "${TEMPLATE_PATH}"
 done

--- a/install.sh
+++ b/install.sh
@@ -3,12 +3,12 @@
 #Copies the template to correct location and creates the intermediate dirs if neccessary
 
 TEMPLATE_PATH=~/Library/Developer/Xcode/Templates/File\ Templates/Source
-# Remove the old template source folder if needed
-rm -r "${TEMPLATE_PATH}"
-# Create the template source folder if needed
+# Create the tempalte source folder if needed
 mkdir -p "${TEMPLATE_PATH}"
 
 for TEMPLATE in *.xctemplate; do
+    # Remove the old template
+    rm -r "${TEMPLATE_PATH}"/"${TEMPLATE}"
     # Copy the new template
     cp -r "${TEMPLATE}" "${TEMPLATE_PATH}"
 done

--- a/install.sh
+++ b/install.sh
@@ -3,12 +3,12 @@
 #Copies the template to correct location and creates the intermediate dirs if neccessary
 
 TEMPLATE_PATH=~/Library/Developer/Xcode/Templates/File\ Templates/Source
-# Create the tempalte source folder if needed
+# Remove the old template source folder if needed
+rm -r "${TEMPLATE_PATH}"
+# Create the template source folder if needed
 mkdir -p "${TEMPLATE_PATH}"
 
 for TEMPLATE in *.xctemplate; do
-    # Remove the old template
-    rm -r "${TEMPLATE_PATH}"/"${TEMPLATE}"
     # Copy the new template
     cp -r "${TEMPLATE}" "${TEMPLATE_PATH}"
 done


### PR DESCRIPTION
**Background Context:** 
- https://catawiki.slack.com/archives/GEZ3TGV8W/p1605546991053000 

**How to test:**
- Open terminal and go-to Xcode template path i.e `cd ~/Library/Developer/Xcode/Templates/File\ Templates/Source`
- Delete all the existing templates from Source folder
- Run `sh install.sh` 

You should not below error message on the console:
<img width="1049" alt="Screenshot 2020-11-16 at 18 15 09" src="https://user-images.githubusercontent.com/5364500/99291055-82f3d280-283f-11eb-82c4-24098e94a8d0.png">
